### PR TITLE
refactor(brew): extract brew operations to scripts/brew-install.sh

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# GitHub Copilot / Agent Instructions — dotfiles
+
+Short summary
+- This is a personal dotfiles repository for macOS development (Neovim, zsh, tmux, Kanata, Home Manager/Nix, package manifests). Treat changes as user-facing environment changes — prefer safe, small edits and PRs for config updates.
+
+High-level architecture (what matters)
+- Top-level components: `nvim/` (profile-based Neovim), `zsh/`, `tmux/`, `kanata/`, `home/` (Home Manager/Nix), `Brewfile` and `scripts/` (installer helpers), `npm/` (manifest + installer).
+- Two supported workflows: "dotfiles" standalone (copy/symlink files, run `install.sh`) and Nix/Home Manager/Darwin (flake-based, see `home/home.nix` and `archive/nix/`).
+
+When you start
+- Read `README.md` (root) and module READMEs (`nvim/README.md`, `kanata/INSTALL-MACOS.md`, `npm/README.md`).
+- Use `./install.sh --help` to see supported flags (`--brewfile`, `--hererocks`, `--npm-globals`, `--update-brewfile`, `--commit-brewfile`).
+
+Important conventions & examples (actionable)
+- Brewfile edits: prefer `./install.sh --update-brewfile` which creates a backup `Brewfile.bak.<UTC timestamp>`; automated commit message format used by the script is `chore(brewfile): add <pkg1> <pkg2>`. If adding packages manually, create a branch and open a PR for review.
+- Neovim profiles: add a profile at `nvim/lua/plugins/profiles/<name>.lua`. Wire detection in `nvim/lua/utils/root.lua` (e.g. check for `package.json`, `charts/` or custom files). Update `nvim/lua/core/statusline.lua` if you add profile icons.
+  - To test: `NVIM_PROFILE=<name> nvim`, inside Neovim run `:Lazy sync`, `:checkhealth`, `:TSUpdate`, and verify `:Mason` / `:checkhealth` for LSP issues.
+- NPM globals: manifest is `npm/npm-globals.txt`; installer is `npm/install-npm-globals.sh` (supports `--manager`, `--dry-run`, `--yes`). Use `npm/install.sh --dry-run` first.
+- Scripts: scripts live under `scripts/`. Keep them executable and add a small `--help`/usage block. Use `bash -n` for quick syntax checks and include a smoke test (`scripts/test_bootstrap.sh` demonstrates expectations for `bootstrap_hererocks.sh`).
+- Home Manager / Nix: local dev wrapper at `~/.config/home-manager/home.nix` imports `home/home.nix` and uses impure evaluation for local testing. For local apply: `nix run github:nix-community/home-manager#home-manager -- switch --impure`. For reproducible application use flakes: `home-manager switch --flake .` or `darwin-rebuild switch --flake .#<machine>`.
+- Kanata (keyboard remapper): macOS requires Karabiner VirtualHIDDevice driver v6.2.0 (see `kanata/INSTALL-MACOS.md`). Validate configs with `kanata -c ~/.dotfiles/kanata/kanata.kbd --check` and run manually with `sudo kanata -c ...` for initial tests.
+
+Testing & verification
+- Unit-like smoke-tests exist as small shell checks (e.g., `scripts/test_bootstrap.sh`). Use these as templates for new script tests.
+- Neovim verification is manual: `nvim` then `:checkhealth`, `:Lazy sync`, `:TSUpdate`.
+- No CI workflows are present in this repo—ask maintainers before adding heavy CI.
+
+Style & safety rules for agents (do not assume anything)
+- Do not modify `Brewfile` and commit automatically without the `--update-brewfile --commit-brewfile` flow or an explicit PR. The installer creates backups — preserve them.
+- Avoid changing Home Manager / system-level config without confirming target machine (darwin flakes reference machines like `#macmini` or `#macbook`).
+- For changes that affect runtime behavior (keyboard, shell, LSPs), include clear 'how to test' steps and at least one smoke command (e.g., `kanata --check`, `:checkhealth` in nvim, `bash -n scripts/...`).
+
+Files to reference when making edits (quick map)
+- repo README: `README.md`
+- installer: `install.sh`, `scripts/bootstrap_hererocks.sh`, `npm/install-npm-globals.sh`
+- Neovim: `nvim/` — detection: `nvim/lua/utils/root.lua`, profiles: `nvim/lua/plugins/profiles/`, keymaps: `nvim/lua/core/keymaps.lua`
+- Home Manager / Nix: `home/home.nix`, `archive/nix/`, `MACHINES.md`, `NIX_DARWIN.md`
+- Kanata: `kanata/kanata.kbd`, `kanata/INSTALL-MACOS.md`
+
+If something is unclear
+- Ask for clarification and link to the file you intend to change (e.g., "I want to add tool X to the Brewfile; do you want it appended automatically or added via a PR?").
+
+Thanks — please review and tell me if you want more detail or example PR templates for common change types.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ chmod +x install.sh
 
 # Install packages from repo Brewfile and also ensure npm global language servers
 ./install.sh --brewfile --npm-globals
+
+# On macOS: disable press-and-hold to enable key repeat (opt-in)
+./install.sh --enable-macos-key-repeat  # add --yes to skip the confirmation prompt
 ```
 
 Advanced options:
@@ -51,6 +54,16 @@ The installer will:
 - Bootstrap Lua 5.1 via `hererocks` (for Neovim plugin support),
 - Optionally install npm global packages used by language servers (when `--npm-globals` is passed),
 - Report which Brewfile was used and any packages appended/committed.
+
+### macOS preferences
+
+- `--enable-macos-key-repeat` — Disable the press-and-hold accent menu and enable key repeat system-wide on macOS. This setting is **opt-in**: pass the flag to apply the change; the installer will prompt for confirmation unless `--yes` is also provided. To verify the setting, run:
+
+```bash
+defaults read -g ApplePressAndHoldEnabled
+```
+
+A value of `0`/`false` indicates key repeat is enabled; restarting affected apps (or logging out/in) may be required for the change to take effect.
 
 ### hererocks & PEP 668
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Advanced options:
 
 - `--update-brewfile` — if you request packages not present in the repo `Brewfile`, append them to the `Brewfile` (creates a timestamped backup). Use this when you want the `Brewfile` to be updated automatically.
 - `--commit-brewfile` — use together with `--update-brewfile` to automatically commit the appended changes (requires `git` and will create a backup prior to committing).
+- `--dry-run` — perform a dry run of Brew operations (prints actions without executing). This uses the new helper `scripts/brew-install.sh --dry-run` under the hood; you can call that script directly for advanced usage.
 
 The installer will:
 - Prefer installing via the repository `Brewfile` (or a temporary Brewfile generated from requested packages),

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Advanced options:
 
 - `--update-brewfile` — if you request packages not present in the repo `Brewfile`, append them to the `Brewfile` (creates a timestamped backup). Use this when you want the `Brewfile` to be updated automatically.
 - `--commit-brewfile` — use together with `--update-brewfile` to automatically commit the appended changes (requires `git` and will create a backup prior to committing).
+- `--dry-run` — perform a dry run of Brew operations (prints actions without executing). This uses the helper script `scripts/brew-install.sh --dry-run` under the hood; you can call that script directly for advanced workflows.
+
+Direct use: `scripts/brew-install.sh`
+
+For advanced or programmatic workflows you can call the helper directly. It supports the same options plus a `--file <path>` override and prints machine-readable markers so callers can parse results.
+
+Examples:
+
+```bash
+# Dry-run (safe; prints actions and BREW-INFO markers)
+./scripts/brew-install.sh --dry-run git curl
+
+# Append missing packages and commit (creates a backup first)
+./scripts/brew-install.sh --update --commit git node
+
+# Run bundle for a specific Brewfile
+./scripts/brew-install.sh --file /path/to/Brewfile
+```
+
+Notes:
+
+- The script emits lines prefixed with `BREW-INFO:` that indicate important events: `USED <file>`, `APPENDED <pkgs>`, `BACKUP <path>`, and `COMMIT <sha>`.
+- When using `--commit` the script requires `git` and will create a timestamped backup before modifying the Brewfile; prefer committing from a branch and opening a PR for review.
 - `--dry-run` — perform a dry run of Brew operations (prints actions without executing). This uses the new helper `scripts/brew-install.sh --dry-run` under the hood; you can call that script directly for advanced usage.
 
 The installer will:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ This repository prefers using the `Brewfile` to manage Homebrew installs. The in
 
 Note: invoking a subcommand (for example `./install.sh config`) will not trigger the interactive "install core" prompt; subcommands are treated as explicit actions. To perform the recommended core install non-interactively, use `./install.sh --all` or pass `--yes` to skip confirmations.
 
+Example (fully non-interactive bootstrap):
+
+```bash
+./install.sh --all --yes
+```
+
+
 Common usage:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cd ~/dotfiles
 
 This repository prefers using the `Brewfile` to manage Homebrew installs. The installer supports applying the repo `Brewfile`, bootstrapping `hererocks`, and installing a small set of helper packages.
 
+Note: invoking a subcommand (for example `./install.sh config`) will not trigger the interactive "install core" prompt; subcommands are treated as explicit actions. To perform the recommended core install non-interactively, use `./install.sh --all` or pass `--yes` to skip confirmations.
+
 Common usage:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ DO_UPDATE_BREWFILE=0
 DO_COMMIT_BREWFILE=0
 DO_CONFIG_PRESS_AND_HOLD=0
 ASSUME_YES=0
+# Tracks whether a subcommand was explicitly invoked (prevents interactive core prompt when a subcommand is present)
+SUBCOMMAND_USED=0
 
 # Temporary file tracking for safe cleanup
 TMP_FILES=()
@@ -277,6 +279,7 @@ install_npm_globals() {
 # Support both subcommand-style: 'install <subcommand> [options]' and legacy flags
 if [ "$#" -gt 0 ] && [[ "$1" != -* ]]; then
 	# Treat first arg as a subcommand
+	SUBCOMMAND_USED=1
 	case "$1" in
 		core)
 			DO_BREWFILE=1; DO_HEREROCKS=1; DO_NPM=1; shift
@@ -345,8 +348,8 @@ else
 	done
 fi
 
-# If nothing selected, ask interactively
-if [ ${#BREW_REQUIRED[@]} -eq 0 ] && [ $DO_HEREROCKS -eq 0 ] && [ $DO_PYPNVIM -eq 0 ]; then
+# If nothing selected and no subcommand was given, ask interactively
+if [ ${#BREW_REQUIRED[@]} -eq 0 ] && [ $DO_HEREROCKS -eq 0 ] && [ $DO_PYPNVIM -eq 0 ] && [ $SUBCOMMAND_USED -eq 0 ]; then
 	echo "No options provided. Install core set? (hererocks and Brewfile packages)"
 	if [ $ASSUME_YES -eq 1 ]; then
 		answer=y

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,8 @@ Subcommands:
   npm                  Install npm global language servers (delegates to npm/install.sh)
   config --press-and-hold     Configure macOS: disable press-and-hold (enable key repeat)
 
+Note: invoking a subcommand (e.g., `config` or `brew`) will not trigger the interactive "Install core set" prompt; subcommands are treated as explicit actions.
+
 Legacy (flag-style) options:
   --all                Same as 'core'
   --hererocks          Bootstrap hererocks (Lua 5.1)

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ Usage: $(basename "$0") [options] OR $(basename "$0") <subcommand> [options]
 
 Subcommands:
   core                 Install recommended set (Brewfile, hererocks, npm)
-  brew [--update] [--commit]  Run brew bundle; --update appends missing packages; --commit commits Brewfile
+  brew [--update] [--commit] [--dry-run]  Run brew bundle (delegates to scripts/brew-install.sh); --update appends missing packages; --commit commits Brewfile; --dry-run prints actions without executing
   pynvim               Install pynvim (pip --user)
   hererocks            Bootstrap hererocks (Lua 5.1)
   npm                  Install npm global language servers (delegates to npm/install.sh)

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,8 @@ Examples:
   $(basename "$0") brew --update --commit
   $(basename "$0") pynvim
   $(basename "$0") config --press-and-hold
+  # Fully non-interactive bootstrap (installs core set without prompts)
+  $(basename "$0") --all --yes
 EOF
 }     
 

--- a/install.sh
+++ b/install.sh
@@ -13,24 +13,57 @@ DO_BREWFILE=0
 DO_NPM=0
 DO_UPDATE_BREWFILE=0
 DO_COMMIT_BREWFILE=0
+DO_CONFIG_PRESS_AND_HOLD=0
 ASSUME_YES=0
+
+# Temporary file tracking for safe cleanup
+TMP_FILES=()
+mktemp_file() {
+	local tmpl="${1:-tmp.XXXXXXXX}"
+	local f
+	f="$(mktemp -t "$tmpl")" || return 1
+	# track for cleanup
+	TMP_FILES+=("$f")
+	printf '%s' "$f"
+}
+cleanup_tmp_files() {
+	for f in "${TMP_FILES[@]:-}"; do
+		[ -n "$f" ] && rm -rf "$f"
+	done
+}
+trap cleanup_tmp_files EXIT
 
 print_usage() {
 	cat <<'EOF'
-Usage: $(basename "$0") [options]
+Usage: $(basename "$0") [options] OR $(basename "$0") <subcommand> [options]
 
-Options:
-  --all                Install recommended set (hererocks, Brewfile, npm)
+Subcommands:
+  core                 Install recommended set (Brewfile, hererocks, npm)
+  brew [--update] [--commit]  Run brew bundle; --update appends missing packages; --commit commits Brewfile
+  pynvim               Install pynvim (pip --user)
+  hererocks            Bootstrap hererocks (Lua 5.1)
+  npm                  Install npm global language servers (delegates to npm/install.sh)
+  config --press-and-hold     Configure macOS: disable press-and-hold (enable key repeat)
+
+Legacy (flag-style) options:
+  --all                Same as 'core'
   --hererocks          Bootstrap hererocks (Lua 5.1)
   --pynvim             Install pynvim (pip --user)
   --brewfile           Run: brew bundle --file=Brewfile (repo root)
   --update-brewfile    Append missing packages to repo Brewfile (creates backup)
   --commit-brewfile    Commit appended Brewfile changes (requires git)
   --npm-globals        Install npm global language servers
+  --enable-macos-key-repeat  Enable macOS key repeat (alias for config --press-and-hold)
   --yes, -y            Assume yes for prompts
   --help               Show this help
+
+Examples:
+  $(basename "$0") core
+  $(basename "$0") brew --update --commit
+  $(basename "$0") pynvim
+  $(basename "$0") config --press-and-hold
 EOF
-}
+}     
 
 add_brew() {
 	local pkg="$1"
@@ -241,37 +274,76 @@ install_npm_globals() {
 }
 
 # parse args
-while [ "$#" -gt 0 ]; do
+# Support both subcommand-style: 'install <subcommand> [options]' and legacy flags
+if [ "$#" -gt 0 ] && [[ "$1" != -* ]]; then
+	# Treat first arg as a subcommand
 	case "$1" in
-		--all)
-			# Use the repo Brewfile to install core packages instead of listing them here
-			DO_BREWFILE=1
-			DO_HEREROCKS=1
-			DO_NPM=1
-			shift
+		core)
+			DO_BREWFILE=1; DO_HEREROCKS=1; DO_NPM=1; shift
 			;;
-
-		--hererocks)
-			DO_HEREROCKS=1; shift ;;
-		--pynvim)
+		brew)
+			DO_BREWFILE=1; shift
+			# Parse brew-specific options
+			while [ "$#" -gt 0 ] && [[ "$1" == --* ]]; do
+				case "$1" in
+					--update|--update-brewfile) DO_UPDATE_BREWFILE=1; shift ;;
+					--commit|--commit-brewfile) DO_COMMIT_BREWFILE=1; DO_UPDATE_BREWFILE=1; shift ;;
+					--yes|-y) ASSUME_YES=1; shift ;;
+					--help) print_usage; exit 0 ;;
+					*) echo "Unknown brew option: $1"; print_usage; exit 1 ;;
+				esac
+			done
+			;;
+		pynvim)
 			DO_PYPNVIM=1; shift ;;
-		--brewfile)
-			DO_BREWFILE=1; shift ;;
-		--update-brewfile)
-			DO_UPDATE_BREWFILE=1; shift ;; 
-		--commit-brewfile)
-		# Commit implies updating the Brewfile (append missing packages)
-		DO_COMMIT_BREWFILE=1; DO_UPDATE_BREWFILE=1; shift ;;
-		--npm-globals)
+		hererocks)
+			DO_HEREROCKS=1; shift ;;
+		npm)
 			DO_NPM=1; shift ;;
-		--yes|-y)
-			ASSUME_YES=1; shift ;;
-		--help)
-			print_usage; exit 0 ;;
+		config)
+			shift
+			while [ "$#" -gt 0 ] && [[ "$1" == --* ]]; do
+				case "$1" in
+					--press-and-hold) DO_CONFIG_PRESS_AND_HOLD=1; shift ;;
+					--help) print_usage; exit 0 ;;
+					*) echo "Unknown config option: $1"; print_usage; exit 1 ;;
+				esac
+			done
+			;;
 		*)
-			echo "Unknown arg: $1"; print_usage; exit 1 ;;
+			echo "Unknown subcommand: $1"; print_usage; exit 1 ;;
 	esac
-done
+else
+	# Legacy flag-style parsing
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--all)
+				DO_BREWFILE=1; DO_HEREROCKS=1; DO_NPM=1; shift ;;
+
+			--hererocks)
+				DO_HEREROCKS=1; shift ;;
+			--pynvim)
+				DO_PYPNVIM=1; shift ;;
+			--brewfile)
+				DO_BREWFILE=1; shift ;;
+			--update-brewfile)
+				DO_UPDATE_BREWFILE=1; shift ;; 
+			--commit-brewfile)
+			# Commit implies updating the Brewfile (append missing packages)
+				DO_COMMIT_BREWFILE=1; DO_UPDATE_BREWFILE=1; shift ;;
+			--npm-globals)
+				DO_NPM=1; shift ;;
+			--enable-macos-key-repeat)
+				DO_CONFIG_PRESS_AND_HOLD=1; shift ;;
+			--yes|-y)
+				ASSUME_YES=1; shift ;;
+			--help)
+				print_usage; exit 0 ;;
+			*)
+				echo "Unknown arg: $1"; print_usage; exit 1 ;;
+		esac
+	done
+fi
 
 # If nothing selected, ask interactively
 if [ ${#BREW_REQUIRED[@]} -eq 0 ] && [ $DO_HEREROCKS -eq 0 ] && [ $DO_PYPNVIM -eq 0 ]; then
@@ -297,17 +369,48 @@ if command -v brew >/dev/null 2>&1; then
 	brew update || true
 fi
 
-# Deduplicate BREW_REQUIRED
+# Deduplicate BREW_REQUIRED (portable across macOS bash 3.2 and later)
 if [ ${#BREW_REQUIRED[@]} -gt 0 ]; then
-	mapfile -t BREW_REQUIRED < <(printf "%s\n" "${BREW_REQUIRED[@]}" | awk '!seen[$0]++')
+	unique_pkgs=()
+	for pkg in "${BREW_REQUIRED[@]}"; do
+		found=0
+		for u in "${unique_pkgs[@]}"; do
+			[ "$pkg" = "$u" ] && { found=1; break; }
+		done
+		if [ $found -eq 0 ]; then
+			unique_pkgs+=("$pkg")
+		fi
+	done
+	BREW_REQUIRED=("${unique_pkgs[@]}")
 fi
 
-# Prefer using Brewfile for Homebrew installs. If requested packages exist, generate
-# a temporary Brewfile (based on repo Brewfile when present) and run `brew bundle`.
+# Delegate Brew operations to dedicated script for maintainability
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 BREWFILE_USED=""
+BREW_SCRIPT="$repo_root/scripts/brew-install.sh"
 if [ "$DO_BREWFILE" -eq 1 ] || [ ${#BREW_REQUIRED[@]} -gt 0 ]; then
-	if [ -f "$repo_root/Brewfile" ]; then
+	if [ -x "$BREW_SCRIPT" ]; then
+		# Build args
+		args=()
+		[ $DO_UPDATE_BREWFILE -eq 1 ] && args+=(--update)
+		[ $DO_COMMIT_BREWFILE -eq 1 ] && args+=(--commit)
+		[ $ASSUME_YES -eq 1 ] && args+=(--yes)
+		if [ ${#BREW_REQUIRED[@]} -gt 0 ]; then
+			args+=("${BREW_REQUIRED[@]}")
+		fi
+
+		echo "Delegating brew operations to: $BREW_SCRIPT ${args[*]}"
+		out="$("$BREW_SCRIPT" "${args[@]}" 2>&1)" || true
+		# Forward output for visibility
+		printf "%s\n" "$out"
+		# Parse machine-readable markers
+		BREWFILE_USED=$(printf "%s\n" "$out" | awk -F'BREW-INFO: ' '/BREW-INFO: USED/ {print $2; exit}')
+		APPENDED_PKGS=$(printf "%s\n" "$out" | awk -F'BREW-INFO: ' '/BREW-INFO: APPENDED/ {print $2; exit}')
+		backup_path=$(printf "%s\n" "$out" | awk -F'BREW-INFO: ' '/BREW-INFO: BACKUP/ {print $2; exit}')
+		BREWFILE_COMMIT=$(printf "%s\n" "$out" | awk -F'BREW-INFO: ' '/BREW-INFO: COMMIT/ {print $2; exit}')
+	else
+		echo "Brew script not found at $BREW_SCRIPT; falling back to in-script behavior"
+		if [ -f "$repo_root/Brewfile" ]; then
 		# Repo Brewfile exists
 		if [ ${#BREW_REQUIRED[@]} -eq 0 ]; then
 			if command -v brew >/dev/null 2>&1; then
@@ -401,10 +504,9 @@ cp "$repo_root/Brewfile" "$backup_path"
 				echo "Homebrew not found; please install Homebrew to run 'brew bundle --file=$repo_root/Brewfile' or run it manually."
 			fi
 			else
-			# Create temp Brewfile from repo Brewfile and append missing entries (portable mktemp, cleanup)
-			tmp_brewfile="$(mktemp -t brewfile.XXXXXXXX)"
-			cp "$repo_root/Brewfile" "$tmp_brewfile"
-			trap 'rm -f "$tmp_brewfile"' EXIT
+# Create temp Brewfile from repo Brewfile and append missing entries (portable mktemp, tracked cleanup)
+				tmp_brewfile="$(mktemp_file brewfile.XXXXXXXX)"
+				cp "$repo_root/Brewfile" "$tmp_brewfile"
 			for pkg in "${BREW_REQUIRED[@]}"; do
 				if ! grep -E '^[[:space:]]*(brew|cask) ' "$tmp_brewfile" | sed -E 's/^[[:space:]]*(brew|cask)[[:space:]]+['\''"]?([^'\''"[:space:],]+).*/\2/' | grep -xq -- "$pkg"; then
 					echo "brew \"$pkg\"" >> "$tmp_brewfile"
@@ -417,15 +519,12 @@ cp "$repo_root/Brewfile" "$backup_path"
 			else
 				echo "Homebrew not found; please install Homebrew to run 'brew bundle --file=$tmp_brewfile' or run it manually."
 			fi
-			rm -f "$tmp_brewfile"
-			trap - EXIT
 			fi
 		fi
 	else
 		# No repo Brewfile — create temp Brewfile containing requested packages
 		if [ ${#BREW_REQUIRED[@]} -gt 0 ]; then
-			tmp_brewfile="$(mktemp -t brewfile.XXXXXXXX)"
-			trap 'rm -f "$tmp_brewfile"' EXIT
+			tmp_brewfile="$(mktemp_file brewfile.XXXXXXXX)"
 			for pkg in "${BREW_REQUIRED[@]}"; do
 				echo "brew \"$pkg\"" >> "$tmp_brewfile"
 			done
@@ -436,10 +535,9 @@ cp "$repo_root/Brewfile" "$backup_path"
 			else
 				echo "Homebrew not found; please install Homebrew to run 'brew bundle --file=$tmp_brewfile' or run it manually."
 			fi
-			rm -f "$tmp_brewfile"
-			trap - EXIT
 		fi
 	fi
+fi
 fi
 
 # If a Brewfile run was not performed, fall back to per-package installs
@@ -492,6 +590,17 @@ printf "  python3 -c 'import pynvim' && echo 'pynvim OK' || true\n"
 printf "  nvim --headless -c 'checkhealth nvim-treesitter' -c q\n"
 
 echo "If Neovim still reports missing luarocks, ensure $HEREROCKS_DIR/bin is in your PATH."
+
+# macOS key-repeat setting: apply only when requested via 'config --press-and-hold' or legacy flag
+if [ "${DO_CONFIG_PRESS_AND_HOLD:-0}" -eq 1 ]; then
+	if [ "$(uname -s)" = "Darwin" ]; then
+		# Inform the user and apply the setting; do not fail the script if 'defaults' fails
+		echo "Configuring macOS: disable press-and-hold input (ApplePressAndHoldEnabled=false)"
+		defaults write -g ApplePressAndHoldEnabled -bool false || true
+	else
+		echo "Skipping press-and-hold config: not macOS"
+	fi
+fi
 
 exit 0
 

--- a/scripts/brew-install.sh
+++ b/scripts/brew-install.sh
@@ -3,6 +3,28 @@ set -euo pipefail
 
 # scripts/brew-install.sh
 # Encapsulate Brewfile/brew bundle operations for the dotfiles repo.
+#
+# Usage: scripts/brew-install.sh [options] [packages...]
+#
+# This helper performs the Brewfile/brew bundle work for the top-level installer
+# and is also callable directly for advanced or programmatic workflows.
+# It supports:
+#  - --file <path>   : override Brewfile path
+#  - --update        : append missing packages to Brewfile (creates backup)
+#  - --commit        : commit appended changes (implies --update)
+#  - --dry-run       : print actions without executing (safe)
+#
+# Output markers (machine-readable): lines prefixed with 'BREW-INFO:'
+#  - BREW-INFO: USED <file>
+#  - BREW-INFO: APPENDED <pkgs>
+#  - BREW-INFO: BACKUP <path>
+#  - BREW-INFO: COMMIT <sha>
+#
+# Examples:
+#   ./scripts/brew-install.sh --dry-run git curl
+#   ./scripts/brew-install.sh --update --commit git node
+#   ./scripts/brew-install.sh --file /path/to/Brewfile
+
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 BREWFILE_PATH="$REPO_ROOT/Brewfile"

--- a/scripts/brew-install.sh
+++ b/scripts/brew-install.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/brew-install.sh
+# Encapsulate Brewfile/brew bundle operations for the dotfiles repo.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BREWFILE_PATH="$REPO_ROOT/Brewfile"
+DO_UPDATE=0
+DO_COMMIT=0
+ASSUME_YES=0
+DRY_RUN=0
+PACKAGES=()
+
+print_usage() {
+  cat <<'EOF'
+Usage: $(basename "$0") [options] [packages...]
+
+Options:
+  --file <path>        Path to Brewfile (defaults to repo root/Brewfile)
+  --update             Append missing packages to Brewfile
+  --commit             Commit Brewfile changes (implies --update)
+  --yes, -y            Assume yes for prompts
+  --dry-run            Print actions without executing
+  --help               Show this help
+
+Examples:
+  $(basename "$0") --update --commit git node
+  $(basename "$0") --dry-run curl
+EOF
+}
+
+# Simple logger helpers
+info() { printf 'info: %s\n' "$*"; }
+err() { printf 'error: %s\n' "$*" >&2; }
+
+# Parse args
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --file)
+      shift; BREWFILE_PATH="$1"; shift;;
+    --update)
+      DO_UPDATE=1; shift;;
+    --commit)
+      DO_COMMIT=1; DO_UPDATE=1; shift;;
+    --yes|-y)
+      ASSUME_YES=1; shift;;
+    --dry-run)
+      DRY_RUN=1; shift;;
+    --help)
+      print_usage; exit 0;;
+    --*)
+      err "Unknown option: $1"; print_usage; exit 1;;
+    *)
+      PACKAGES+=("$1"); shift;;
+  esac
+done
+
+# Ensure Brewfile* behavior is understandable
+if [ ! -f "$BREWFILE_PATH" ] && [ $DO_UPDATE -eq 1 ]; then
+  err "Brewfile not found at $BREWFILE_PATH; cannot update a missing Brewfile"
+  exit 1
+fi
+
+# Show actions in dry-run mode
+run_or_echo() {
+  if [ $DRY_RUN -eq 1 ]; then
+    info "DRY RUN: $*"
+  else
+    eval "$*"
+  fi
+}
+
+# Append missing packages to Brewfile (preserves formatting by using brew/cask lines)
+append_missing() {
+  local missing=()
+  for pkg in "${PACKAGES[@]}"; do
+    if [ -f "$BREWFILE_PATH" ]; then
+      if grep -E '^[[:space:]]*(brew|cask) ' "$BREWFILE_PATH" | sed -E 's/^[[:space:]]*(brew|cask)[[:space:]]+[\"\'"']?([^\"\'"'""[:space:],]+).*/\2/' | grep -xq -- "$pkg"; then
+        info "Package $pkg already present in $BREWFILE_PATH"
+      else
+        missing+=("$pkg")
+      fi
+    else
+      missing+=("$pkg")
+    fi
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    info "Missing packages to append: ${missing[*]}"
+    if [ $ASSUME_YES -ne 1 ]; then
+      read -r -p "Append these packages to $BREWFILE_PATH? [Y/n] " ans || true
+      case "$ans" in
+        [Nn]*) info "Skipping append"; return 0;;
+      esac
+    fi
+
+    backup="$BREWFILE_PATH.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+    run_or_echo "cp \"$BREWFILE_PATH\" \"$backup\""
+    info "Created backup: $backup"
+    for p in "${missing[@]}"; do
+      run_or_echo "echo \"brew \"\"$p\"\"\" >> \"$BREWFILE_PATH\""
+    done
+    info "Appended ${#missing[@]} packages to $BREWFILE_PATH"
+    APPENDED_PKGS=("${missing[@]}")
+    # Emit machine-readable info for callers
+    printf 'BREW-INFO: APPENDED %s\n' "${APPENDED_PKGS[*]}"
+    printf 'BREW-INFO: BACKUP %s\n' "$backup"
+  else
+    info "No missing packages to append"
+  fi
+}
+
+# Run brew bundle on given file
+run_bundle() {
+  local file="$1"
+  if ! command -v brew >/dev/null 2>&1; then
+    err "Homebrew not found; please install Homebrew to run 'brew bundle --file=$file'"
+    return 1
+  fi
+  info "Running: brew bundle --file=$file"
+  run_or_echo "brew bundle --file=\"$file\" || true"
+  # Emit used marker for callers
+  printf 'BREW-INFO: USED %s\n' "$file"
+}
+
+# Commit Brewfile if changes detected
+commit_brewfile() {
+  if ! command -v git >/dev/null 2>&1; then
+    err "Git not found; cannot commit Brewfile automatically"
+    return 1
+  fi
+  if git -C "$(dirname "$BREWFILE_PATH")" status --porcelain --untracked-files=normal | grep -q "$(basename "$BREWFILE_PATH")"; then
+    msg="chore(brewfile): add ${APPENDED_PKGS[*]:-}"
+    run_or_echo "git -C \"$(dirname \"$BREWFILE_PATH\")\" add \"$(basename \"$BREWFILE_PATH\")\""
+    if run_or_echo "git -C \"$(dirname \"$BREWFILE_PATH\")\" commit -m \"$msg\""; then
+      BREWFILE_COMMIT=$(git -C "$(dirname "$BREWFILE_PATH")" rev-parse --short HEAD 2>/dev/null || true)
+      info "Committed Brewfile changes: $BREWFILE_COMMIT"
+    # Emit machine-readable commit marker
+    printf 'BREW-INFO: COMMIT %s\n' "$BREWFILE_COMMIT"
+    else
+      err "Failed to commit Brewfile changes; please commit manually"
+      git -C "$(dirname "$BREWFILE_PATH")" status --porcelain --untracked-files=normal | sed 's/^/  /' || true
+    fi
+  else
+    info "No changes to Brewfile to commit"
+  fi
+}
+
+# Main execution flow
+if [ ${#PACKAGES[@]} -eq 0 ] && [ $DO_UPDATE -eq 0 ]; then
+  # No packages specified; just run bundle on Brewfile if present
+  if [ -f "$BREWFILE_PATH" ]; then
+    run_bundle "$BREWFILE_PATH"
+    exit $?
+  else
+    err "No Brewfile found at $BREWFILE_PATH and no packages specified"
+    exit 1
+  fi
+fi
+
+# If packages specified and update requested, append them
+if [ ${#PACKAGES[@]} -gt 0 ] && [ $DO_UPDATE -eq 1 ]; then
+  append_missing
+fi
+
+# If packages specified but no repo Brewfile, create temporary Brewfile
+if [ ${#PACKAGES[@]} -gt 0 ] && [ ! -f "$BREWFILE_PATH" ]; then
+  tmpfile="$(mktemp -t brewfile.XXXXXXXX)"
+  for p in "${PACKAGES[@]}"; do
+    run_or_echo "echo \"brew \"\"$p\"\"\" >> \"$tmpfile\""
+  done
+  run_bundle "$tmpfile"
+  run_or_echo "rm -f \"$tmpfile\""
+  exit 0
+fi
+
+# Otherwise run bundle on the (possibly updated) Brewfile
+run_bundle "$BREWFILE_PATH"
+
+# Optionally commit
+if [ $DO_COMMIT -eq 1 ]; then
+  commit_brewfile
+fi
+
+exit 0

--- a/scripts/test_bootstrap.sh
+++ b/scripts/test_bootstrap.sh
@@ -19,8 +19,24 @@ echo "Syntax check passed for $SCRIPT"
 # Run help and assert it contains 'Usage:'
 if "$SCRIPT" --help | grep -q "Usage:"; then
 	echo "Help output present"
-	exit 0
 else
 	echo "Help output did not contain 'Usage:'"
 	exit 2
 fi
+
+# Smoke test for brew-install.sh (dry-run)
+BREW_SCRIPT="scripts/brew-install.sh"
+if [ -f "$BREW_SCRIPT" ]; then
+	chmod +x "$BREW_SCRIPT"
+	# Use dry-run to avoid touching the system
+	if "$BREW_SCRIPT" --dry-run git curl | grep -q "BREW-INFO: USED"; then
+		echo "brew-install dry-run smoke test passed"
+	else
+		echo "brew-install dry-run did not emit expected markers"
+		exit 3
+	fi
+else
+	echo "$BREW_SCRIPT not found; skipping brew-install smoke test"
+fi
+
+exit 0

--- a/scripts/test_bootstrap.sh
+++ b/scripts/test_bootstrap.sh
@@ -39,4 +39,12 @@ else
 	echo "$BREW_SCRIPT not found; skipping brew-install smoke test"
 fi
 
+# Regression test: ensure 'config' subcommand does not trigger the core-install prompt
+if ./install.sh config 2>&1 | grep -q "No options provided"; then
+	echo "config subcommand incorrectly triggers core-install prompt"
+	exit 4
+else
+	echo "config subcommand did not trigger core prompt (OK)"
+fi
+
 exit 0


### PR DESCRIPTION
Moves Brewfile/brew bundle behavior into a dedicated script for maintainability and testability. Adds dry-run mode and machine-readable markers (BREW-INFO:) for callers. Updates tests (dry-run smoke test) and improves portability in install.sh (portable dedupe + centralized tmp cleanup).