### PR TITLE
chore(docs): remove Home Manager references and replace migration guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,11 @@
 # GitHub Copilot / Agent Instructions — dotfiles
 
 Short summary
-- This is a personal dotfiles repository for macOS development (Neovim, zsh, tmux, Kanata, Home Manager/Nix, package manifests). Treat changes as user-facing environment changes — prefer safe, small edits and PRs for config updates.
+- This is a personal dotfiles repository for macOS development (Neovim, zsh, tmux, Kanata, package manifests). Treat changes as user-facing environment changes — prefer safe, small edits and PRs for config updates.
 
 High-level architecture (what matters)
 - Top-level components: `nvim/` (profile-based Neovim), `zsh/`, `tmux/`, `kanata/`, `Brewfile` and `scripts/` (installer helpers), `npm/` (manifest + installer).
-- Two supported workflows: "dotfiles" standalone (copy/symlink files, run `install.sh`) and Nix/Home Manager/Darwin (flake-based, see `home/home.nix` and `archive/nix/`).
+- Primary workflow: "dotfiles" standalone (copy/symlink files, run `install.sh`). Nix/Home Manager was previously supported but is no longer maintained in this repo.
 
 When you start
 - Read `README.md` (root) and module READMEs (`nvim/README.md`, `kanata/INSTALL-MACOS.md`, `npm/README.md`).
@@ -17,7 +17,7 @@ Important conventions & examples (actionable)
   - To test: `NVIM_PROFILE=<name> nvim`, inside Neovim run `:Lazy sync`, `:checkhealth`, `:TSUpdate`, and verify `:Mason` / `:checkhealth` for LSP issues.
 - NPM globals: manifest is `npm/npm-globals.txt`; installer is `npm/install-npm-globals.sh` (supports `--manager`, `--dry-run`, `--yes`). Use `npm/install.sh --dry-run` first.
 - Scripts: scripts live under `scripts/`. Keep them executable and add a small `--help`/usage block. Use `bash -n` for quick syntax checks and include a smoke test (`scripts/test_bootstrap.sh` demonstrates expectations for `bootstrap_hererocks.sh`).
-- Home Manager / Nix: *previously supported* via `~/.config/home-manager/home.nix` and flakes; this repository no longer actively maintains Nix/Home Manager configuration.
+- (Legacy) Nix/Home Manager configuration is no longer maintained in this repository.
 - Kanata (keyboard remapper): macOS requires Karabiner VirtualHIDDevice driver v6.2.0 (see `kanata/INSTALL-MACOS.md`). Validate configs with `kanata -c ~/.dotfiles/kanata/kanata.kbd --check` and run manually with `sudo kanata -c ...` for initial tests.
 
 Testing & verification
@@ -27,14 +27,14 @@ Testing & verification
 
 Style & safety rules for agents (do not assume anything)
 - Do not modify `Brewfile` and commit automatically without the `--update-brewfile --commit-brewfile` flow or an explicit PR. The installer creates backups — preserve them.
-- Avoid changing Home Manager / system-level config without confirming target machine (darwin flakes reference machines like `#macmini` or `#macbook`).
+- Avoid changing system-level config without confirming the target machine (darwin flakes reference machines like `#macmini` or `#macbook`).
 - For changes that affect runtime behavior (keyboard, shell, LSPs), include clear 'how to test' steps and at least one smoke command (e.g., `kanata --check`, `:checkhealth` in nvim, `bash -n scripts/...`).
 
 Files to reference when making edits (quick map)
 - repo README: `README.md`
 - installer: `install.sh`, `scripts/bootstrap_hererocks.sh`, `npm/install-npm-globals.sh`
 - Neovim: `nvim/` — detection: `nvim/lua/utils/root.lua`, profiles: `nvim/lua/plugins/profiles/`, keymaps: `nvim/lua/core/keymaps.lua`
-- Home Manager / Nix: `home/home.nix`, `archive/nix/`, `MACHINES.md`, `NIX_DARWIN.md`
+- Nix artifacts referenced historically: `archive/nix/`, `MACHINES.md`, `NIX_DARWIN.md`
 - Kanata: `kanata/kanata.kbd`, `kanata/INSTALL-MACOS.md`
 
 If something is unclear

--- a/MACHINES.md
+++ b/MACHINES.md
@@ -13,17 +13,8 @@ Support untuk multiple macOS machines dengan berbeda architecture:
 
 ## 📁 Configuration Structure
 
-```
-dotfiles/
-├── flake.nix                      # Main entry with multi-machine support
-├── darwin/
-│   ├── configuration.nix          # Shared system config
-│   └── machines.nix               # Machine-specific overrides
-└── home/
-    ├── home.nix                   # Shared home config
-    └── zsh/
-        └── init.zsh               # Shell initialization
-```
+This file historically documented a Nix/nix-darwin-based multi-machine configuration (flakes + darwin modules). Nix support has been removed from active maintenance in this repository — the previous Nix artifacts were removed or archived. Use the repository `Brewfile` and `install.sh` for Homebrew-based installation and machine bootstrapping instead.
+
 
 ## 🚀 Installation
 
@@ -281,29 +272,8 @@ scutil --get LocalHostName
 
 ## 📚 Examples
 
-### Only install on MacBook
-```nix
-# In home.nix
-home.packages = with pkgs; [
-] ++ lib.optionals (machineType == "macbook") [
-  some-laptop-tool
-];
-```
+The Nix/Home Manager examples previously included here have been removed as Home Manager is no longer maintained in this repository. For machine-specific package installation and configuration, prefer using per-machine scripts or the `Brewfile` and `install.sh` flow. If you need to reintroduce per-machine declarative config, consider adding small scripts under `scripts/` or a documented convention in this repository.
 
-### Different node version per machine
-```nix
-# In home/home.nix
-programs.nodejs.version = 
-  if machineType == "macbook" then "18" else "20";
-```
-
-### Machine-specific aliases
-```bash
-# In home/zsh/init.zsh
-if [[ $(hostname) == *"macbook"* ]]; then
-  alias battery='pmset -g battery'
-fi
-```
 
 ## 🔐 Security Notes
 

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -23,7 +23,7 @@ export NODE_OPTIONS="--max_old_space_size=4096"
 export PATH="/Applications/RustRover.app/Contents/MacOS:${PATH}"
 
 # Homebrew
-# HOMEBREW_NO_AUTO_UPDATE is managed by Home Manager via home.sessionVariables
+# HOMEBREW_NO_AUTO_UPDATE may be set in your environment (e.g., CI or personal configs).
 # This file is sourced for *login* shells (e.g., Terminal.app sessions). We run
 # `brew shellenv` here so login sessions receive Homebrew's PATH and environment.
 # For non-login or system-level shells (e.g., GUI apps or some VSCode shells),
@@ -47,7 +47,7 @@ if [ -n "$BREW_BIN" ] && [ -x "$BREW_BIN" ]; then
 fi
 
 # FZF defaults
-# Managed by Home Manager's `home.sessionVariables`
+# Managed via shell configuration or local session variables (adjust as needed)
 
 # Python venv activation remains in zprofile (login-time activation)
 [[ -f ~/.config/python-venv/bin/activate ]] && source ~/.config/python-venv/bin/activate

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -42,8 +42,8 @@ source ~/.zshrc
 ```
 
 Notes:
-- A previous `home/zsh/init.zsh` file was migrated into the consolidated `./.zshrc`. The original file has been backed up as `home/zsh/init.zsh.bak` in the repo.
-- If you use Nix / Home Manager, you may still prefer to manage your shell via Home Manager; this repo supports both workflows but the canonical shell config is the repo `.zshrc`.
+- A previous `init.zsh` file was migrated into the consolidated `./.zshrc`; a backup is available in the repository history if needed.
+- The canonical shell config for this repo is `./.zshrc`. Copy or source it to your home directory to apply the repo config (see usage step above).
 
 
 ## 🔄 Update


### PR DESCRIPTION
Title: chore: remove `home/` module (Home Manager) and update docs

Summary
-------
This PR removes the `home/` module (Home Manager configuration) from the repository and updates documentation to remove Home Manager-specific workflow references.

Why
---
- The repository is moving to a Homebrew-first workflow and no longer maintains Home Manager/Nix-based user configuration.
- Removing the `home/` module avoids confusion and reduces maintenance burden.

What changed
------------
- Deleted: `home/home.nix`, `home/README.md`.
- Updated: `zsh/README.md` to reference the consolidated `./.zshrc` and to remove references to `home/zsh`.
- Updated: `.github/copilot-instructions.md` to remove active Home Manager usage and mark it as previously supported.

Testing
-------
- Verify local `zsh` setup uses `~/.zshrc` from the repo and no `home/` paths remain in docs.
- Confirm `install.sh` and `Brewfile` work as expected without attempting to run Nix or Home Manager.

Rollback
--------
To rollback: restore `home/` from git history or revert this PR.

Checklist
--------
- [x] Remove `home/` module files
- [x] Update docs referencing `home/` and Home Manager
- [ ] Add tests or verification steps if required (not necessary for docs-only change)
